### PR TITLE
Add OUTDRV control

### DIFF
--- a/src/PCA9633.cpp
+++ b/src/PCA9633.cpp
@@ -133,6 +133,20 @@ void PCA9633::setLdrStateAll(uint8_t state) {
     writeReg(REG_LEDOUT, newReg);
 }
 
+void PCA9633::setDrvState(uint8_t state) {
+
+    uint8_t prevReg = readReg(REG_MODE2);
+    uint8_t newReg;
+
+    // first clear both bits of drv
+    newReg = prevReg & ~(0b11 << BIT_OUTDRV);
+
+    // second set new state to specified drv
+    newReg |= (state << BIT_OUTDRV);
+
+    writeReg(REG_MODE2, newReg);
+}
+
 void PCA9633::setAutoIncrement(uint8_t option) {
 
     uint8_t newReg;

--- a/src/PCA9633.cpp
+++ b/src/PCA9633.cpp
@@ -138,8 +138,8 @@ void PCA9633::setDrvState(uint8_t state) {
     uint8_t prevReg = readReg(REG_MODE2);
     uint8_t newReg;
 
-    // first clear both bits of drv
-    newReg = prevReg & ~(0b11 << BIT_OUTDRV);
+    // first clear the OUTDRV bit
+    newReg = prevReg & ~(1 << BIT_OUTDRV);
 
     // second set new state to specified drv
     newReg |= (state << BIT_OUTDRV);

--- a/src/PCA9633.h
+++ b/src/PCA9633.h
@@ -205,7 +205,6 @@
 /**
  * The 4 LED outputs are configured with a totem pole structure
  */
-
 #define OUTDRV_TOTEM_POLE 1
 
 // LED driver output state, LEDOUT (page 14, below table 13)

--- a/src/PCA9633.h
+++ b/src/PCA9633.h
@@ -195,7 +195,9 @@
  */
 #define BIT_LDR0    0
 
-
+// LED driver output type, OUTDRV (page 11, MODE2 register table)
+#define OUTDRV_OPEN_DRAIN 0
+#define OUTDRV_TOTEM_POLE 1
 
 // LED driver output state, LEDOUT (page 14, below table 13)
 
@@ -384,6 +386,15 @@ public:
     * @param w  Value for white color channel
     */
     void setRGBW(uint8_t r, uint8_t g, uint8_t b, uint8_t w);
+
+    /**
+    * Set the global driver output type for a given channel. There are two types:
+    *   - OUTDRV_OPEN_DRAIN
+    *   - OUTDRV_TOTEM_POLE
+    *
+    * @param state  One of the two possible states
+    */
+    void setDrvState(uint8_t state);
 
     /**
     * Set the LED driver output state for a given channel. There are four states:

--- a/src/PCA9633.h
+++ b/src/PCA9633.h
@@ -195,8 +195,17 @@
  */
 #define BIT_LDR0    0
 
-// LED driver output type, OUTDRV (page 11, MODE2 register table)
+// LED driver output type, OUTDRV (page 12, table 9, MODE2 register table)
+
+/**
+ * The 4 LED outputs are configured with an open-drain structure
+ */
 #define OUTDRV_OPEN_DRAIN 0
+
+/**
+ * The 4 LED outputs are configured with a totem pole structure
+ */
+
 #define OUTDRV_TOTEM_POLE 1
 
 // LED driver output state, LEDOUT (page 14, below table 13)


### PR DESCRIPTION
This is an addition to allow use of totem-pole outputs.

Hopefully it is easy enough to understand.